### PR TITLE
fix: validate handles shell-style commands (#1)

### DIFF
--- a/docs/dev-tracking/issue-1-validate-command-shell-parsing.md
+++ b/docs/dev-tracking/issue-1-validate-command-shell-parsing.md
@@ -1,0 +1,26 @@
+# Issue #1 Development Tracking
+
+- Issue: https://github.com/BinaRoy/cangjie-build-repair-kit/issues/1
+- Branch: `issue/1-validate-mis-parses-shell-commands-and-rejects-valid-verify-command-cd-bash-lc`
+
+## Scope
+
+Fix `driver.main validate` command extraction so shell-style commands do not produce false "command not found" errors for shell builtins/flags.
+
+## Implementation Notes
+
+- Updated `_extract_required_commands` in `driver/main.py`:
+  - switched to `shlex.split(..., posix=True)` for normalized shell token parsing.
+  - added shell wrapper handling for combined bash flags such as `-lc`.
+  - added simple shell-chain parsing for `&&`, `||`, `;`, `|` separators.
+  - ignored common shell builtins at command head (e.g., `cd`) so only external executables are validated.
+  - deduplicated extracted command candidates while preserving order.
+- Added tests in `tests/test_validate_command.py`:
+  - `test_extract_required_commands_for_shell_chain`
+  - `test_extract_required_commands_for_bash_lc_wrapper`
+  - `test_validate_command_accepts_shell_style_verify_command`
+
+## Verification Evidence
+
+- `python3 -m unittest tests.test_validate_command -v`
+  - Result: PASS (10 tests)

--- a/driver/main.py
+++ b/driver/main.py
@@ -142,14 +142,25 @@ def _looks_like_path_token(token: str) -> bool:
 
 def _extract_required_commands(command: str) -> list[str]:
     try:
-        tokens = shlex.split(command, posix=False)
+        tokens = shlex.split(command, posix=True)
     except ValueError:
         return []
     if not tokens:
         return []
 
-    required = [tokens[0]]
     wrappers = {"cmd", "cmd.exe", "powershell", "powershell.exe", "pwsh", "pwsh.exe", "bash", "sh"}
+    shell_builtins = {
+        "cd",
+        "echo",
+        "export",
+        "set",
+        "unset",
+        "alias",
+        "source",
+        ".",
+    }
+    separators = {"&&", "||", ";", "|"}
+    required: list[str] = [tokens[0]]
     head = tokens[0].lower()
     if head in wrappers and len(tokens) > 1:
         marker_index = None
@@ -158,9 +169,14 @@ def _extract_required_commands(command: str) -> list[str]:
                 if token.lower() in ("/c", "/k"):
                     marker_index = i
                     break
-        else:
+        elif head in {"powershell", "powershell.exe", "pwsh", "pwsh.exe"}:
             for i, token in enumerate(tokens[1:], start=1):
                 if token in ("-c", "-Command", "-command", "-File", "-file"):
+                    marker_index = i
+                    break
+        else:
+            for i, token in enumerate(tokens[1:], start=1):
+                if token == "-c" or (token.startswith("-") and "c" in token[1:]):
                     marker_index = i
                     break
         if marker_index is not None and marker_index + 1 < len(tokens):
@@ -172,7 +188,21 @@ def _extract_required_commands(command: str) -> list[str]:
                 required.append(nested)
         elif len(tokens) > 1:
             required.append(tokens[1])
-    return required
+        return list(dict.fromkeys(required))
+
+    required = []
+    at_command_head = True
+    for token in tokens:
+        if token in separators:
+            at_command_head = True
+            continue
+        if not at_command_head:
+            continue
+        at_command_head = False
+        if token.lower() in shell_builtins:
+            continue
+        required.append(token)
+    return list(dict.fromkeys(required))
 
 
 def _check_command_availability(command: str, workdir: Path) -> list[str]:

--- a/tests/test_validate_command.py
+++ b/tests/test_validate_command.py
@@ -12,6 +12,15 @@ class ValidateCommandTests(unittest.TestCase):
     def test_extract_required_commands_for_wrapped_command(self) -> None:
         self.assertEqual(_extract_required_commands("cmd /c run_hvigor.cmd"), ["cmd", "run_hvigor.cmd"])
 
+    def test_extract_required_commands_for_shell_chain(self) -> None:
+        self.assertEqual(_extract_required_commands("cd runtime && cjpm test"), ["cjpm"])
+
+    def test_extract_required_commands_for_bash_lc_wrapper(self) -> None:
+        self.assertEqual(
+            _extract_required_commands("bash -lc 'cd runtime && cjpm test'"),
+            ["bash", "cjpm"],
+        )
+
     def test_validate_command_passes_for_valid_config(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -32,6 +41,34 @@ class ValidateCommandTests(unittest.TestCase):
                         "command_timeout_sec = 60",
                         'editable_paths = ["src"]',
                         'readonly_paths = ["readonly"]',
+                        "artifact_checks = []",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            policy_cfg.write_text("", encoding="utf-8")
+
+            self.assertEqual(_validate_command(str(project_cfg), str(policy_cfg)), 0)
+
+    def test_validate_command_accepts_shell_style_verify_command(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            workdir = root / "work"
+            (workdir / "src").mkdir(parents=True)
+
+            project_cfg = root / "project.toml"
+            policy_cfg = root / "policy.toml"
+            project_cfg.write_text(
+                "\n".join(
+                    [
+                        'project_name = "shell-style-project"',
+                        'project_type = "non_ui"',
+                        f'workdir = "{workdir.as_posix()}"',
+                        'adapter = "cjpm"',
+                        f'verify_command = "bash -lc \'cd src && {sys.executable} --version\'"',
+                        "command_timeout_sec = 60",
+                        'editable_paths = ["src"]',
+                        "readonly_paths = []",
                         "artifact_checks = []",
                     ]
                 ),


### PR DESCRIPTION
Closes #1

## Summary
- fix `_extract_required_commands` to parse shell-style command chains and wrapper forms like `bash -lc`
- ignore shell builtins at command head (for example `cd`) during executable availability checks
- add regression tests for `cd ... && ...` and `bash -lc` command extraction plus validate pass case
- add issue tracking note under `docs/dev-tracking/`

## Test Evidence
- `python3 -m unittest tests.test_validate_command -v` (pass)
- `python3 -m unittest discover -s tests -q` (pass)

## Risk / Rollback
- Risk: command extraction behavior changed for wrapper parsing; mitigated by focused and full-suite tests
- Rollback: revert commit `4d32cac`

## Priority Confirmation
- processed as current queue order: #1 first
