### PR TITLE
fix: bootstrap non-ui monorepo module detection (#2)

### DIFF
--- a/docs/dev-tracking/issue-2-bootstrap-monorepo-module-detection.md
+++ b/docs/dev-tracking/issue-2-bootstrap-monorepo-module-detection.md
@@ -1,0 +1,28 @@
+# Issue #2 Development Tracking
+
+- Issue: https://github.com/BinaRoy/cangjie-build-repair-kit/issues/2
+- Branch: `issue/2-bootstrap-nonui-path-auto-detection-fails-on-monorepo-root-and-creates-invalid-editable-paths`
+
+## Scope
+
+Fix `bootstrap-nonui` so monorepo roots with nested Cangjie modules generate a valid module-specific workdir/editable paths configuration.
+
+## Implementation Notes
+
+- Added `_detect_non_ui_module_roots(root)` in `driver/main.py` to recursively locate `cjpm.toml` module roots.
+- Updated `_bootstrap_non_ui` to:
+  - choose a module root automatically (nearest depth, then lexical order)
+  - set generated `workdir` to the selected module root
+  - detect `editable_paths` relative to selected module root
+  - avoid forcing `<fill_verify_command>` when selected module already has `cjpm.toml`
+  - append a warning block in `FOLLOW_GUIDE.md` when multiple module candidates are detected
+- Added regression tests in `tests/test_bootstrap_nonui.py`:
+  - `test_bootstrap_nonui_selects_nested_module_workdir`
+  - `test_bootstrap_nonui_warns_when_multiple_modules_detected`
+
+## Verification Evidence
+
+- `python3 -m unittest tests.test_bootstrap_nonui -v`
+  - Result: PASS (4 tests)
+- `python3 -m unittest discover -s tests -q`
+  - Result: PASS (83 tests)

--- a/driver/main.py
+++ b/driver/main.py
@@ -433,13 +433,17 @@ def _bootstrap_non_ui(project_root: str, output_dir: str, project_name: str, for
     guide_path = out / "FOLLOW_GUIDE.md"
 
     project_cfg = _load_toml(project_path)
-    detected_editables = [p for p in ["src", "source", "lib", "cjpm.toml"] if (root / p).exists()]
+    module_candidates = _detect_non_ui_module_roots(root)
+    selected_root = module_candidates[0] if module_candidates else root
+    project_cfg["workdir"] = selected_root.as_posix()
+
+    detected_editables = [p for p in ["src", "source", "lib", "cjpm.toml"] if (selected_root / p).exists()]
     if detected_editables:
         project_cfg["editable_paths"] = detected_editables
     else:
         project_cfg["editable_paths"] = ["src", "cjpm.toml"]
 
-    if not (root / "cjpm.toml").exists():
+    if not (selected_root / "cjpm.toml").exists():
         project_cfg["verify_command"] = "<fill_verify_command>"
         project_cfg["test_command"] = ""
 
@@ -456,21 +460,45 @@ def _bootstrap_non_ui(project_root: str, output_dir: str, project_name: str, for
         "- `verify_command` (build command)",
         "- `test_command` (optional but recommended)",
         "- `editable_paths` (already auto-detected, verify before run)",
-        "",
-        "## 3) Validate",
-        f"`python3 -m driver.main validate --project-config {project_path.as_posix()} --policy-config {policy_path.as_posix()}`",
-        "",
-        "## 4) Run repair loop",
-        f"`python3 -m driver.main run --project-config {project_path.as_posix()} --policy-config {policy_path.as_posix()}`",
-        "",
-        "## 5) Inspect outputs",
-        "- `runs/<run_id>/summary.json`",
-        "- `runs/<run_id>/report.md`",
-        "- `runs/<run_id>/iter_*.json`",
     ]
+    if len(module_candidates) > 1:
+        guide_lines.extend(
+            [
+                "",
+                "## Module Detection Warning",
+                f"- Multiple `cjpm.toml` candidates detected: {len(module_candidates)}",
+                f"- Selected workdir: `{selected_root.as_posix()}`",
+                f"- Candidates: `{', '.join(p.as_posix() for p in module_candidates)}`",
+            ]
+        )
+    guide_lines.extend(
+        [
+            "",
+            "## 3) Validate",
+            f"`python3 -m driver.main validate --project-config {project_path.as_posix()} --policy-config {policy_path.as_posix()}`",
+            "",
+            "## 4) Run repair loop",
+            f"`python3 -m driver.main run --project-config {project_path.as_posix()} --policy-config {policy_path.as_posix()}`",
+            "",
+            "## 5) Inspect outputs",
+            "- `runs/<run_id>/summary.json`",
+            "- `runs/<run_id>/report.md`",
+            "- `runs/<run_id>/iter_*.json`",
+        ]
+    )
     guide_path.write_text("\n".join(guide_lines) + "\n", encoding="utf-8")
     print(f"bootstrap guide generated: {guide_path.as_posix()}")
     return 0
+
+
+def _detect_non_ui_module_roots(root: Path) -> list[Path]:
+    candidates: set[Path] = set()
+    ignored_parts = {".git", "target", "build", ".idea", ".vscode", "__pycache__"}
+    for manifest in root.rglob("cjpm.toml"):
+        if any(part in ignored_parts for part in manifest.parts):
+            continue
+        candidates.add(manifest.parent.resolve())
+    return sorted(candidates, key=lambda p: (len(p.relative_to(root).parts), p.as_posix()))
 
 
 def _write_simple_toml(path: Path, data: dict) -> None:

--- a/tests/test_bootstrap_nonui.py
+++ b/tests/test_bootstrap_nonui.py
@@ -55,6 +55,52 @@ class BootstrapNonUITests(unittest.TestCase):
             text = (out / "project.demo2.toml").read_text(encoding="utf-8")
             self.assertIn('verify_command = "<fill_verify_command>"', text)
 
+    def test_bootstrap_nonui_selects_nested_module_workdir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            project_root = root / "repo"
+            module_root = project_root / "modules" / "core"
+            (module_root / "src").mkdir(parents=True)
+            (module_root / "cjpm.toml").write_text('name = "core"\n', encoding="utf-8")
+            out = root / "out"
+
+            rc = _bootstrap_non_ui(
+                project_root=project_root.as_posix(),
+                output_dir=out.as_posix(),
+                project_name="nested",
+                force=True,
+            )
+
+            self.assertEqual(rc, 0)
+            text = (out / "project.nested.toml").read_text(encoding="utf-8")
+            self.assertIn(f'workdir = "{module_root.as_posix()}"', text)
+            self.assertIn('editable_paths = ["src", "cjpm.toml"]', text)
+            self.assertNotIn('verify_command = "<fill_verify_command>"', text)
+
+    def test_bootstrap_nonui_warns_when_multiple_modules_detected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            project_root = root / "repo"
+            module_a = project_root / "module-a"
+            module_b = project_root / "module-b"
+            (module_a / "src").mkdir(parents=True)
+            (module_b / "src").mkdir(parents=True)
+            (module_a / "cjpm.toml").write_text('name = "a"\n', encoding="utf-8")
+            (module_b / "cjpm.toml").write_text('name = "b"\n', encoding="utf-8")
+            out = root / "out"
+
+            rc = _bootstrap_non_ui(
+                project_root=project_root.as_posix(),
+                output_dir=out.as_posix(),
+                project_name="multi",
+                force=True,
+            )
+
+            self.assertEqual(rc, 0)
+            guide_text = (out / "FOLLOW_GUIDE.md").read_text(encoding="utf-8")
+            self.assertIn("multiple", guide_text.lower())
+            self.assertIn("cjpm.toml", guide_text)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #2

## Summary
- add recursive non-UI module root detection based on `cjpm.toml`
- update `bootstrap-nonui` to select a module-specific workdir instead of always using repository root
- detect `editable_paths` from selected module root
- add FOLLOW_GUIDE warning block when multiple module candidates are detected
- add regression tests for nested-module selection and multi-module warning

## Test Evidence
- `python3 -m unittest tests.test_bootstrap_nonui -v` (pass)
- `python3 -m unittest discover -s tests -q` (pass)

## Risk / Rollback
- Risk: auto-selected module root may differ from user intent in uncommon multi-module layouts
- Mitigation: explicit warning with selected workdir and candidate list in FOLLOW_GUIDE
- Rollback: revert commit `95fdb61`

## Priority Confirmation
- processed as current queue order: #2 second
