### PR TITLE
fix: avoid premature no-knowledge stop for rule-based syntax (#3)

### DIFF
--- a/docs/dev-tracking/issue-3-knowledge-hit-gate-for-syntax-rule-based.md
+++ b/docs/dev-tracking/issue-3-knowledge-hit-gate-for-syntax-rule-based.md
@@ -1,0 +1,28 @@
+# Issue #3 Development Tracking
+
+- Issue: https://github.com/BinaRoy/cangjie-build-repair-kit/issues/3
+- Branch: `issue/3-default-policy-blocks-repair-loop-before-planning-when-local-knowledge-hits-are-empty`
+
+## Scope
+
+Avoid premature `stop_no_knowledge_hits` for rule-based syntax/compile failures so the planner can still attempt deterministic repair planning when knowledge hits are empty.
+
+## Implementation Notes
+
+- Updated `driver/loop.py` knowledge gate flow:
+  - added `_should_relax_knowledge_hit_gate(active_strategy, error)`.
+  - relaxed `min_knowledge_hits` enforcement only when:
+    - active strategy is `RuleBasedStrategy`
+    - error category is `syntax` or `compile`
+- Kept strict gate behavior for non-rule-based strategies (including real LLM path) to preserve safety expectations.
+- Added regression test in `tests/test_loop_injection.py`:
+  - `test_syntax_error_does_not_stop_on_no_knowledge_hits_for_rule_based`
+- Verified existing LLM safety gate test still passes:
+  - `test_real_llm_is_not_called_when_knowledge_evidence_missing`
+
+## Verification Evidence
+
+- `python3 -m unittest tests.test_loop_injection tests.test_real_llm_safety -v`
+  - Result: PASS (5 tests)
+- `python3 -m unittest discover -s tests -q`
+  - Result: PASS (84 tests)

--- a/driver/loop.py
+++ b/driver/loop.py
@@ -183,8 +183,9 @@ def run_loop(
             knowledge_provider_selection.provider,
             len(knowledge_hits),
         )
+        relax_min_hit_gate = _should_relax_knowledge_hit_gate(active_strategy, error)
         if policy.require_knowledge_lookup_on_failure:
-            if len(knowledge_hits) < policy.min_knowledge_hits:
+            if not relax_min_hit_gate and len(knowledge_hits) < policy.min_knowledge_hits:
                 store.write_patch_plan(i, empty_patch_plan)
                 decision = "stop_no_knowledge_hits"
                 _archive_failure_case(
@@ -449,6 +450,11 @@ def _build_knowledge_provider_decision(
         if isinstance(extra, dict):
             decision.update(extra)
     return decision
+
+
+def _should_relax_knowledge_hit_gate(active_strategy: StrategyProtocol, error: ErrorSchema) -> bool:
+    # Rule-based strategy should still attempt deterministic planning for common parser/compiler failures.
+    return isinstance(active_strategy, RuleBasedStrategy) and error.category in {"syntax", "compile"}
 
 
 def _extract_model_route_decision(strategy: StrategyProtocol) -> dict[str, Any]:

--- a/tests/test_loop_injection.py
+++ b/tests/test_loop_injection.py
@@ -90,6 +90,49 @@ class LoopInjectionTests(unittest.TestCase):
 
             self.assertEqual(calls, ["parser", "strategy", "applier", "verifier"])
 
+    def test_syntax_error_does_not_stop_on_no_knowledge_hits_for_rule_based(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base_dir = Path(tmp)
+            workdir = base_dir / "work"
+            (workdir / "src").mkdir(parents=True)
+            project = ProjectConfig(
+                project_name="x-syntax",
+                project_type="non_ui",
+                workdir=str(workdir),
+                adapter="cjpm",
+                verify_command="cjpm build",
+                editable_paths=["src"],
+                repair_strategy="rule_based",
+            )
+            policy = PolicyConfig(
+                max_iterations=1,
+                allow_apply_patch=False,
+                require_preflight=False,
+                require_knowledge_lookup_on_failure=True,
+                min_knowledge_hits=1,
+            )
+
+            def parser(_: str) -> ErrorSchema:
+                return ErrorSchema(
+                    category="syntax",
+                    file="src/main.cj",
+                    line=1,
+                    message="syntax error",
+                    context="x",
+                    fingerprint="fp-syntax",
+                )
+
+            summary = run_loop(
+                base_dir=base_dir,
+                run_id="inject-knowledge-syntax",
+                project=project,
+                policy=policy,
+                adapter=_FailingAdapter(),
+                parser=parser,
+            )
+
+            self.assertNotEqual(summary.stop_reason, "stop_no_knowledge_hits")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #3

## Summary
- relax `min_knowledge_hits` gate for rule-based planning when error category is `syntax`/`compile`
- keep strict knowledge gate behavior for non-rule-based strategies (including LLM paths)
- add regression test ensuring syntax failures with empty knowledge hits do not stop at `stop_no_knowledge_hits`
- keep real-LLM safety test passing for strict gate behavior

## Test Evidence
- `python3 -m unittest tests.test_loop_injection tests.test_real_llm_safety -v` (pass)
- `python3 -m unittest discover -s tests -q` (pass)

## Risk / Rollback
- Risk: rule-based strategy may continue one step further on low-context compile failures
- Mitigation: scope limited to `RuleBasedStrategy` and `syntax`/`compile` categories only
- Rollback: revert commit `f741981`

## Priority Confirmation
- processed as current queue order: #3 third
