### PR TITLE
docs: clarify MVP safe-mode non-repairing path (#4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - Agent workflow source-of-truth: `docs/agent_issue_pr_workflow.md`
 - Release/build notes: `docs/git_and_release_workflow.md`
 - Issue autopilot entry: `scripts/issue_autopilot.sh`
+- MVP safe-mode behavior and repair-enabling guide: `docs/mvp_safe_mode_and_repairing.md`
 
 ## 1. What problem this project solves
 

--- a/docs/dev-tracking/issue-4-safe-mode-documentation-and-guidance.md
+++ b/docs/dev-tracking/issue-4-safe-mode-documentation-and-guidance.md
@@ -1,0 +1,29 @@
+# Issue #4 Development Tracking
+
+- Issue: https://github.com/BinaRoy/cangjie-build-repair-kit/issues/4
+- Branch: `issue/4-mvp-safe-mode-returns-can-apply-false-for-compile-syntax-error-no-auto-fix-path`
+
+## Scope
+
+Resolve confusion around `can_apply=false` for generic syntax/compile failures in MVP safe mode by explicitly documenting diagnosis-only behavior and actionable configuration to enable repairing strategies.
+
+## Implementation Notes
+
+- Updated fallback rationale in `repair/strategies/rule_based.py` to explicitly state:
+  - diagnosis-only safe mode behavior
+  - detected family / knowledge hints
+  - how to enable auto-repair (`repair_strategy` + `allow_apply_patch`)
+- Updated fallback `diff_summary` wording to match diagnosis-only safe mode.
+- Added guide doc `docs/mvp_safe_mode_and_repairing.md`:
+  - current safe-mode behavior
+  - why `stop_no_patch_applied` happens
+  - exact config path for enabling stronger auto-repair strategies
+- Added README pointer to new guide.
+- Added test assertion in `tests/test_rule_based_strategy.py` to enforce rationale includes diagnosis-only and `repair_strategy` guidance.
+
+## Verification Evidence
+
+- `python3 -m unittest tests.test_rule_based_strategy -v`
+  - Result: PASS (2 tests)
+- `python3 -m unittest discover -s tests -q`
+  - Result: PASS (84 tests)

--- a/docs/mvp_safe_mode_and_repairing.md
+++ b/docs/mvp_safe_mode_and_repairing.md
@@ -1,0 +1,34 @@
+# MVP Safe Mode and Repair-Enabling Guide
+
+## Current behavior
+
+The default rule-based planner keeps a diagnosis-first safe mode for generic failures:
+
+- It can generate deterministic patches for explicit high-confidence patterns already implemented in rules.
+- For unmatched compile/syntax/generic failures, it returns `can_apply=false` and records rationale for traceability.
+
+This behavior is intentional in MVP to avoid low-confidence automatic edits.
+
+## Why you may see `stop_no_patch_applied`
+
+If the strategy returns no actionable patch (`can_apply=false`), the loop will stop with:
+
+- `stop_no_patch_applied` when `allow_apply_patch=true`
+- `stop_patch_disabled_by_policy` when `allow_apply_patch=false`
+
+## How to enable stronger auto-repair
+
+Use a repair-capable strategy and keep patch application enabled:
+
+1. In project config:
+   - set `repair_strategy = "llm"` or `repair_strategy = "multi_llm"`
+   - configure model settings (`llm_api_url`, `llm_api_key`, `llm_model`, etc.)
+2. In policy config:
+   - set `allow_apply_patch = true`
+3. Run validation and loop:
+   - `python3 -m driver.main validate --project-config <project.toml> --policy-config <policy.toml>`
+   - `python3 -m driver.main run --project-config <project.toml> --policy-config <policy.toml>`
+
+## Scope note
+
+If you need deterministic auto-fixes for additional syntax patterns in rule-based mode, add narrowly-scoped pattern rules with tests first, then verify with project test suite.

--- a/repair/strategies/rule_based.py
+++ b/repair/strategies/rule_based.py
@@ -29,12 +29,13 @@ class RuleBasedStrategy(RepairStrategy):
             )
 
         rationale = (
-            "MVP planner is in safe mode and does not auto-edit files yet. "
-            f"Detected family={error.family}, matched knowledge={hit_titles}."
+            "MVP planner is in diagnosis-only safe mode for generic failures and does not auto-edit files. "
+            f"Detected family={error.family}, matched knowledge={hit_titles}. "
+            "To enable auto-repair flow, configure a repair-capable `repair_strategy` and keep `allow_apply_patch=true`."
         )
         return PatchPlan(
             can_apply=False,
             rationale=rationale,
-            diff_summary="No patch generated in MVP safe mode.",
+            diff_summary="No patch generated in diagnosis-only MVP safe mode.",
             actions=[],
         )

--- a/tests/test_rule_based_strategy.py
+++ b/tests/test_rule_based_strategy.py
@@ -40,6 +40,8 @@ class RuleBasedStrategyTests(unittest.TestCase):
         self.assertFalse(plan.can_apply)
         self.assertIn("family=compile", plan.rationale)
         self.assertIn("k1", plan.rationale)
+        self.assertIn("diagnosis-only", plan.rationale.lower())
+        self.assertIn("repair_strategy", plan.rationale)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #4

## Summary
- clarify fallback rationale in `RuleBasedStrategy` as diagnosis-only MVP behavior
- add explicit guidance in rationale on enabling auto-repair via `repair_strategy` + `allow_apply_patch`
- add dedicated guide: `docs/mvp_safe_mode_and_repairing.md`
- link the new guide from `README.md`
- add regression assertion to keep rationale guidance present

## Test Evidence
- `python3 -m unittest tests.test_rule_based_strategy -v` (pass)
- `python3 -m unittest discover -s tests -q` (pass)

## Risk / Rollback
- Risk: none on runtime patch behavior; change is explanatory/doc-focused
- Rollback: revert commit `60e4a1c`

## Priority Confirmation
- processed as current queue order: #4 fourth
