### PR TITLE
fix: provide actionable manual guidance in rule-based diagnosis (#9)

### DIFF
--- a/docs/dev-tracking/issue-9-rule-based-manual-fix-guidance.md
+++ b/docs/dev-tracking/issue-9-rule-based-manual-fix-guidance.md
@@ -1,0 +1,22 @@
+# Issue #9 Development Tracking
+
+- Issue: https://github.com/BinaRoy/cangjie-build-repair-kit/issues/9
+- Branch: `issue/9-rule-based-diagnosis-mode-detects-compile-errors-but-provides-no-actionable-manual-fix-guidance`
+
+## Scope
+
+Provide actionable manual-fix guidance in rule-based diagnosis mode when no automatic patch is generated.
+
+## Implementation Notes
+
+- Updated `repair/strategies/rule_based.py`:
+  - Added `_build_manual_fix_guidance(error)` helper.
+  - Included manual fix guidance in fallback rationale when `can_apply=false`.
+  - Guidance now includes probable location (`file:line` when available) and concrete next steps (inspect syntax region, apply minimal fix, rerun build).
+- Updated test `tests/test_rule_based_strategy.py`:
+  - Ensures fallback rationale contains file/line location and "manual fix" wording.
+
+## Verification Evidence
+
+- `python3 -m unittest tests.test_rule_based_strategy -v` PASS
+- `python3 -m unittest discover -s tests -q` PASS (84 tests)

--- a/repair/strategies/rule_based.py
+++ b/repair/strategies/rule_based.py
@@ -31,6 +31,7 @@ class RuleBasedStrategy(RepairStrategy):
         rationale = (
             "MVP planner is in diagnosis-only safe mode for generic failures and does not auto-edit files. "
             f"Detected family={error.family}, matched knowledge={hit_titles}. "
+            f"{_build_manual_fix_guidance(error)} "
             "To enable auto-repair flow, configure a repair-capable `repair_strategy` and keep `allow_apply_patch=true`."
         )
         return PatchPlan(
@@ -39,3 +40,16 @@ class RuleBasedStrategy(RepairStrategy):
             diff_summary="No patch generated in diagnosis-only MVP safe mode.",
             actions=[],
         )
+
+
+def _build_manual_fix_guidance(error: ErrorSchema) -> str:
+    location = "unknown location"
+    if error.file and error.line is not None:
+        location = f"{error.file}:{error.line}"
+    elif error.file:
+        location = error.file
+    steps = (
+        f"Manual fix guidance: inspect {location}, then verify bracket/token pairing around the reported syntax region, "
+        "apply the minimal text fix, and re-run build."
+    )
+    return steps

--- a/tests/test_rule_based_strategy.py
+++ b/tests/test_rule_based_strategy.py
@@ -42,6 +42,8 @@ class RuleBasedStrategyTests(unittest.TestCase):
         self.assertIn("k1", plan.rationale)
         self.assertIn("diagnosis-only", plan.rationale.lower())
         self.assertIn("repair_strategy", plan.rationale)
+        self.assertIn("src/main.cj:1", plan.rationale)
+        self.assertIn("manual fix", plan.rationale.lower())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #9

## Summary
- add actionable manual-fix guidance in rule-based diagnosis fallback rationale
- include probable location (`file:line`) when available
- include concrete next steps: inspect syntax region, apply minimal text fix, rerun build
- add regression assertion to keep manual guidance wording and location in rationale

## Test Evidence
- `python3 -m unittest tests.test_rule_based_strategy -v` (pass)
- `python3 -m unittest discover -s tests -q` (pass)

## Risk / Rollback
- Risk: low; patch behavior unchanged (`can_apply=false` fallback still non-editing)
- Rollback: revert commit `aa0e7ae`

## Priority Confirmation
- processed as current open issue queue item: #9
